### PR TITLE
Fixes for the Docker image: Work around gpsoauth issues

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,6 +1,14 @@
+# syntax=docker/dockerfile:1
+
+# Create a venv using the larger base image (which contains gcc).
+FROM python:3.11-bullseye AS builder
+RUN python3 -m venv /venv
+COPY requirements.txt /requirements.txt
+RUN /venv/bin/pip3 install --no-cache-dir -r /requirements.txt
+
+# Copy the venv to a fresh "slim" image.
 FROM python:3.11-slim-bullseye
+COPY --from=builder /venv /venv
 WORKDIR /app
-COPY requirements.txt requirements.txt
-RUN pip3 install --no-cache-dir -r requirements.txt
 COPY . .
-CMD ["python3", "./app.py"]
+CMD ["/venv/bin/python3", "app.py"]

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,8 +1,6 @@
-FROM python:3.9
+FROM python:3.11-slim-bullseye
 WORKDIR /app
 COPY requirements.txt requirements.txt
-RUN apt-get update \
-&& pip install --no-cache-dir --upgrade pip \
-&& pip install --no-cache-dir -r requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
 COPY . .
 CMD ["python3", "./app.py"]

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -4,3 +4,4 @@ pyyaml==6.0
 yamale==4.0.4
 schedule==1.2.0
 pytest==7.3.2
+urllib3<2


### PR DESCRIPTION
These changes in the `Dockerfile` and the `requirements.txt` stop issue https://github.com/flecmart/keep2todoist/issues/29 from showing up in future Docker images by working around these two gpsoauth issues:

- https://github.com/simon-weber/gpsoauth/issues/48: gpsoauth currently has problems with OpenSSL 3, so we explicitly use the latest Debian Bullseye base image which contains a working OpenSSL version.
- https://github.com/simon-weber/gpsoauth/issues/52: The `requirements.txt` would now install Version 2 of urllib3 which doesn't work the the latest gpsoauth release, so we pin urllib3 to the latest version 1.

Additionally I've also added some optimizations to the `Dockerfile`:

- Use the much smaller "slim" version of the Python base image, it contains everything we need.
- Don't run `apt-get update`, it doesn't actually do anything for us because we never install a Debian package.
- Upgrading pip is not necessary.

Those changes combine reduce the size of the resulting Docker images from around 1 GB to 170 MB.

