### PR TITLE
Revert "Bump gkeepapi from 0.14.2 to 0.15.0"

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,4 +1,4 @@
-gkeepapi==0.15.0
+gkeepapi==0.14.2
 todoist-api-python==2.1.3
 pyyaml==6.0.1
 yamale==4.0.4


### PR DESCRIPTION
Reverts flecmart/keep2todoist#40

version causes `gkeepapi.exception.BrowserLoginRequiredException` in my tests.

will revert for now and look for solutions